### PR TITLE
Dev/simplify links

### DIFF
--- a/logseq/block.go
+++ b/logseq/block.go
@@ -94,14 +94,15 @@ func (b *Block) IsPublic() bool {
 	return false
 }
 
-// PageLinks returns all page links found in the block
-func (b *Block) PageLinks() []*Link {
-	return b.Content.PageLinks
-}
+// Links returns all links found in the block
+func (b *Block) Links() []*Link {
+	links := []*Link{}
 
-// ResourceLinks returns all resource links found in the block
-func (b *Block) ResourceLinks() []*Link {
-	return b.Content.ResourceLinks
+	for _, link := range b.Content.Links {
+		links = append(links, link)
+	}
+
+	return links
 }
 
 func (b *Block) String() string {

--- a/logseq/block_content.go
+++ b/logseq/block_content.go
@@ -9,19 +9,15 @@ import (
 
 // BlockContent represents the content of a block in a Logseq graph.
 type BlockContent struct {
-	Block         *Block  `json:"block"` // Block that contains this content
-	Markdown      string  `json:"markdown"`
-	HTML          string  `json:"html"`
-	PageLinks     []*Link `json:"page_links"`
-	ResourceLinks []*Link `json:"resource_links"`
-	AssetLinks    []*Link `json:"asset_links"`
+	Block    *Block           `json:"block"` // Block that contains this content
+	Markdown string           `json:"markdown"`
+	HTML     string           `json:"html"`
+	Links    map[string]*Link `json:"links"`
 }
 
 func NewEmptyBlockContent() *BlockContent {
 	return &BlockContent{
-		PageLinks:     []*Link{},
-		ResourceLinks: []*Link{},
-		AssetLinks:    []*Link{},
+		Links: map[string]*Link{},
 	}
 }
 
@@ -33,132 +29,31 @@ func NewBlockContent(block *Block, rawSource string) *BlockContent {
 	return content
 }
 
-// AddLinkToAsset adds a link to an asset from the block content.
-func (bc *BlockContent) AddLinkToAsset(path string, label string) (*Link, error) {
-	asset := NewAsset(path)
-	foundLink := bc.FindLinkToAsset(path)
-	if foundLink != nil {
-		return nil, ErrorDuplicateAssetLink{AssetPath: path}
+// AddLink adds a link to the block content.
+func (bc *BlockContent) AddLink(link Link) (Link, error) {
+	log.Debugf("Adding link from block %s: %s", bc.Block, link.LinkPath)
+
+	_, ok := bc.FindLink(link.LinkPath)
+	if ok {
+		return Link{}, ErrorDuplicateLink{link.LinkPath}
 	}
 
-	link := Link{
-		LinksFrom: bc.Block,
-		LinksTo:   &asset,
-		Label:     label,
-		IsEmbed:   false,
-	}
-
-	bc.AssetLinks = append(bc.AssetLinks, &link)
-
-	return &link, nil
-}
-
-// AddEmbeddedLinkToAsset adds an embedded link to an asset from the block content.
-func (bc *BlockContent) AddEmbeddedLinkToAsset(path string, label string) (*Link, error) {
-	link, err := bc.AddLinkToAsset(path, label)
-	if err != nil {
-		return nil, errors.Wrap(err, "adding link to asset")
-	}
-
-	link.IsEmbed = true
+	link.LinksFrom = bc.Block
+	bc.Links[link.LinkPath] = &link
 
 	return link, nil
 }
 
-func (bc *BlockContent) FindLinkToAsset(assetPath string) *Link {
-	for _, link := range bc.AssetLinks {
-		target := link.LinksTo.(*Asset)
-		if target.PathInGraph == assetPath {
-			return link
-		}
-	}
+// FindLink returns a link by path.
+func (bc *BlockContent) FindLink(path string) (*Link, bool) {
+	link, ok := bc.Links[path]
 
-	return nil
-
-}
-
-// FindLinkToPage checks if the block content already links to the page.
-func (bc *BlockContent) FindLinkToPage(pageName string) *Link {
-	for _, link := range bc.PageLinks {
-		target := link.LinksTo.(*Page)
-		if target.Name == pageName {
-			return link
-		}
-	}
-
-	return nil
-}
-
-// FindLinkToResource checks if the block content already links to the external resource.
-func (bc *BlockContent) FindLinkToResource(resource ExternalResource) *Link {
-	for _, link := range bc.ResourceLinks {
-		if link.LinksTo == resource {
-			return link
-		}
-	}
-
-	return nil
+	return link, ok
 }
 
 func (bc *BlockContent) IsCodeBlock() bool {
 	codeBlockRe := regexp.MustCompile("```")
 	return codeBlockRe.MatchString(bc.Markdown)
-}
-
-// AddLinkToPage adds a link to a page to the block content.
-func (bc *BlockContent) AddLinkToPage(pageName string, label string) (*Link, error) {
-	log.Debugf("Adding link to page: label=%s, target=%s", label, pageName)
-
-	existingLink := bc.FindLinkToPage(pageName)
-	if existingLink != nil {
-		return nil, ErrorDuplicatePageLink{PageName: pageName}
-	}
-
-	// This is more of a bookmark, to be replaced with an actual Page link during InContext.
-	target := NewEmptyPage()
-	target.Name = pageName
-	link := Link{
-		LinksFrom: bc.Block,
-		LinksTo:   &target,
-		Label:     label,
-		IsEmbed:   false,
-	}
-	log.Info("Adding link: ", link)
-
-	bc.PageLinks = append(bc.PageLinks, &link)
-
-	return &link, nil
-}
-
-// AddLinkToResource adds a link to an external resource to the block content.
-func (bc *BlockContent) AddLinkToResource(resource ExternalResource, label string) (*Link, error) {
-	existingLink := bc.FindLinkToResource(resource)
-	if existingLink != nil {
-		return nil, ErrorDuplicateResourceLink{Resource: resource}
-	}
-
-	link := Link{
-		LinksFrom: bc.Block,
-		LinksTo:   resource,
-		Label:     label,
-		IsEmbed:   false,
-	}
-
-	bc.ResourceLinks = append(bc.ResourceLinks, &link)
-
-	return &link, nil
-}
-
-// AddEmbeddedLinkToResource adds an embedded link to an external resource.
-func (bc *BlockContent) AddEmbeddedLinkToResource(resource ExternalResource, label string) (*Link, error) {
-	link, err := bc.AddLinkToResource(resource, label)
-	if err != nil {
-		return nil, err
-	}
-
-	link.IsEmbed = true
-
-	return link, nil
 }
 
 // SetMarkdown sets the markdown content of the block.
@@ -186,28 +81,25 @@ func (bc *BlockContent) findLinks() error {
 
 func (bc *BlockContent) findPageLinks() {
 	pageLinkRe := regexp.MustCompile(`\[\[(.+?)\]\]`)
-	pageLinks := []*Link{}
 
 	if bc.IsCodeBlock() {
 		return
 	}
 
 	for _, match := range pageLinkRe.FindAllStringSubmatch(bc.Markdown, -1) {
-		raw, pageName := match[0], match[1]
-		// This is more of a bookmark, to be replaced with an actual Page link by the graph.
-		target := NewEmptyPage()
-		target.Name = pageName
+		pageName := match[1]
+		log.Debugf("Found page link: [%s] -> %s", match[0], pageName)
 		link := Link{
-			Raw:       raw,
-			LinksFrom: bc.Block,
-			LinksTo:   &target,
-			Label:     pageName,
-			IsEmbed:   false,
+			LinkPath: pageName,
+			Label:    pageName,
+			LinkType: LinkTypePage,
+			IsEmbed:  false,
 		}
-		pageLinks = append(pageLinks, &link)
+		_, err := bc.AddLink(link)
+		if err != nil {
+			log.Errorf("Error adding link to page: %s", err)
+		}
 	}
-
-	bc.PageLinks = pageLinks
 }
 
 func (bc *BlockContent) findResourceLinks() error {
@@ -217,32 +109,22 @@ func (bc *BlockContent) findResourceLinks() error {
 		isEmbed, label, resourceUrl, isAsset := match[1], match[2], match[3], match[4]
 		log.Debugf("Found resource link: ->%s<- label=%s uri=%s", match[0], label, resourceUrl)
 
-		if isAsset != "" {
-			if isEmbed == "!" {
-				_, err := bc.AddEmbeddedLinkToAsset(resourceUrl, label)
-				if err != nil {
-					return errors.Wrap(err, "adding embedded link to asset")
-				}
-			} else {
-				_, err := bc.AddLinkToAsset(resourceUrl, label)
-				if err != nil {
-					return errors.Wrap(err, "adding link to asset")
-				}
-			}
-		} else {
-			resource := ExternalResource{Uri: resourceUrl}
+		linkType := LinkTypeResource
 
-			if isEmbed == "!" {
-				_, err := bc.AddEmbeddedLinkToResource(resource, label)
-				if err != nil {
-					return errors.Wrap(err, "adding embedded link to resource")
-				}
-			} else {
-				_, err := bc.AddLinkToResource(resource, label)
-				if err != nil {
-					return errors.Wrap(err, "adding link to resource")
-				}
-			}
+		if isAsset != "" {
+			linkType = LinkTypeAsset
+		}
+
+		link := Link{
+			LinkPath: resourceUrl,
+			Label:    label,
+			LinkType: linkType,
+			IsEmbed:  isEmbed == "!",
+		}
+
+		_, err := bc.AddLink(link)
+		if err != nil {
+			return errors.Wrap(err, "adding resource link")
 		}
 	}
 

--- a/logseq/block_content.go
+++ b/logseq/block_content.go
@@ -9,7 +9,7 @@ import (
 
 // BlockContent represents the content of a block in a Logseq graph.
 type BlockContent struct {
-	Block    *Block           `json:"block"` // Block that contains this content
+	Block    *Block           `json:"-"` // Block that contains this content
 	Markdown string           `json:"markdown"`
 	HTML     string           `json:"html"`
 	Links    map[string]*Link `json:"links"`
@@ -87,9 +87,10 @@ func (bc *BlockContent) findPageLinks() {
 	}
 
 	for _, match := range pageLinkRe.FindAllStringSubmatch(bc.Markdown, -1) {
-		pageName := match[1]
-		log.Debugf("Found page link: [%s] -> %s", match[0], pageName)
+		raw, pageName := match[0], match[1]
+		log.Debugf("Found page link: [%s] -> %s", raw, pageName)
 		link := Link{
+			Raw:      raw,
 			LinkPath: pageName,
 			Label:    pageName,
 			LinkType: LinkTypePage,
@@ -106,8 +107,8 @@ func (bc *BlockContent) findResourceLinks() error {
 	resourceLinkRe := regexp.MustCompile(`(!?)\[(.*?)\]\(((../assets/)?.*?)\)`)
 
 	for _, match := range resourceLinkRe.FindAllStringSubmatch(bc.Markdown, -1) {
-		isEmbed, label, resourceUrl, isAsset := match[1], match[2], match[3], match[4]
-		log.Debugf("Found resource link: ->%s<- label=%s uri=%s", match[0], label, resourceUrl)
+		raw, isEmbed, label, resourceUrl, isAsset := match[0], match[1], match[2], match[3], match[4]
+		log.Debugf("Found resource link: ->%s<- label=%s uri=%s", raw, label, resourceUrl)
 
 		linkType := LinkTypeResource
 
@@ -116,6 +117,7 @@ func (bc *BlockContent) findResourceLinks() error {
 		}
 
 		link := Link{
+			Raw:      raw,
 			LinkPath: resourceUrl,
 			Label:    label,
 			LinkType: linkType,

--- a/logseq/block_test.go
+++ b/logseq/block_test.go
@@ -3,6 +3,7 @@ package logseq_test
 import (
 	"testing"
 
+	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/assert"
 
 	"export-logseq/logseq"
@@ -85,37 +86,24 @@ func TestBlock_IsPublic_OverridesParent(t *testing.T) {
 	assert.True(t, child.IsPublic())
 }
 
-func TestBlock_PageLinks_Empty(t *testing.T) {
+func TestBlock_Links(t *testing.T) {
 	block := logseq.NewEmptyBlock()
-	links := block.PageLinks()
+	link := logseq.Link{
+		LinkPath: gofakeit.URL(),
+		Label:    gofakeit.Phrase(),
+		LinkType: logseq.LinkTypeResource,
+		IsEmbed:  false,
+	}
+	link, _ = block.Content.AddLink(link)
+	links := block.Links()
+
+	assert.Contains(t, links, &link)
+}
+
+func TestBlock_Links_Empty(t *testing.T) {
+	block := logseq.NewEmptyBlock()
+	links := block.Links()
 
 	assert.NotNil(t, links)
 	assert.Empty(t, links)
-}
-
-func TestBlock_PageLinks(t *testing.T) {
-	block := logseq.NewEmptyBlock()
-	pageName, label := PageName(), LinkLabel()
-	link, _ := block.Content.AddLinkToPage(pageName, label)
-	links := block.PageLinks()
-
-	assert.Contains(t, links, link)
-}
-
-func TestBlock_ResourceLinks_Empty(t *testing.T) {
-	block := logseq.NewEmptyBlock()
-	links := block.ResourceLinks()
-
-	assert.NotNil(t, links)
-	assert.Empty(t, links)
-}
-
-func TestBlock_ResourceLinks(t *testing.T) {
-	block := logseq.NewEmptyBlock()
-	resource := logseq.ExternalResource{Uri: "https://example.com"}
-	label := "Example"
-	link, _ := block.Content.AddLinkToResource(resource, label)
-	links := block.ResourceLinks()
-
-	assert.Contains(t, links, link)
 }

--- a/logseq/errors.go
+++ b/logseq/errors.go
@@ -8,31 +8,13 @@ func (p DisconnectedPageError) Error() string {
 	return "page not found in graph: " + p.PageName
 }
 
-// ErrorDuplicateAssetLink is returned when a block content already has a link to an asset and another link is added.
-type ErrorDuplicateAssetLink struct {
-	AssetPath string
+// ErrorDuplicateLink is returned when adding a link path that's already been linked.
+type ErrorDuplicateLink struct {
+	LinkPath string
 }
 
-func (e ErrorDuplicateAssetLink) Error() string {
-	return "duplicate asset link: " + e.AssetPath
-}
-
-// ErrorDuplicatePageLink is returned when a block content already has a link to a page and another link is added.
-type ErrorDuplicatePageLink struct {
-	PageName string
-}
-
-func (e ErrorDuplicatePageLink) Error() string {
-	return "duplicate page link: " + e.PageName
-}
-
-// ErrorDuplicateResourceLink is returned when a block content already has a link to a resource and another link is added.
-type ErrorDuplicateResourceLink struct {
-	Resource ExternalResource
-}
-
-func (e ErrorDuplicateResourceLink) Error() string {
-	return "duplicate resource link: " + e.Resource.Uri
+func (e ErrorDuplicateLink) Error() string {
+	return "duplicate link: " + e.LinkPath
 }
 
 // AssetExistsError is returned when an asset is added to a graph that already has an asset with the same path.

--- a/logseq/fixtures_test.go
+++ b/logseq/fixtures_test.go
@@ -10,11 +10,6 @@ func BlockContent() *logseq.BlockContent {
 	page := Page()
 	return page.Root.Content
 }
-func ExternalResource() logseq.ExternalResource {
-	return logseq.ExternalResource{
-		Uri: gofakeit.URL(),
-	}
-}
 
 func Page() logseq.Page {
 	page := logseq.NewEmptyPage()

--- a/logseq/graph.go
+++ b/logseq/graph.go
@@ -284,19 +284,18 @@ func (g *Graph) prepBlockForSite(block *Block) {
 		}
 
 		linkString := "*" + link.Label + "*"
-		permalink := "/" + link.LinkPath
 
 		targetPage, err := g.FindPage(link.LinkPath)
 		if err != nil {
 			if _, ok := err.(DisconnectedPageError); ok {
-				log.Warnf("Block %v placeholder link: >%v<", block.ID, link.Label)
-			} else {
 				log.Fatalf("Linking page: %v", err)
+			} else {
+				log.Warnf("Block %v placeholder link: >%v<", block.ID, link.Label)
 			}
 		}
 
 		if targetPage != nil {
-			permalink = "/" + targetPage.PathInSite
+			permalink := "/" + targetPage.PathInSite
 			log.Debug("Linking ", block.ID, " to ", permalink)
 			linkString = "[" + link.Label + "](" + permalink + ")"
 		}

--- a/logseq/graph.go
+++ b/logseq/graph.go
@@ -149,9 +149,9 @@ func (g *Graph) FindLinksToPage(page *Page) []*Link {
 	links := []*Link{}
 
 	for _, link := range g.PageLinks() {
-		linkTarget := link.LinksTo.(*Page)
+		linkTarget := link.LinkPath
 		log.Debug("Checking link from ", link.LinksFrom, " to ", linkTarget)
-		if linkTarget.Name == page.Name {
+		if page.Name == linkTarget {
 			log.Debug("Found link to ", page.Name, " in ", link.LinksFrom)
 			links = append(links, link)
 		}
@@ -179,12 +179,25 @@ func (g *Graph) FindPage(name string) (*Page, error) {
 	return nil, PageNotFoundError{name}
 }
 
+// Links returns all links found in the graph.
+func (g *Graph) Links() []*Link {
+	links := []*Link{}
+
+	for _, page := range g.Pages {
+		links = append(links, page.Links()...)
+	}
+
+	return links
+}
+
 // PageLinks returns all page links found in the graph.
 func (g *Graph) PageLinks() []*Link {
 	links := []*Link{}
 
-	for _, page := range g.Pages {
-		links = append(links, page.PageLinks()...)
+	for _, link := range g.Links() {
+		if link.LinkType == LinkTypePage {
+			links = append(links, link)
+		}
 	}
 
 	return links
@@ -228,10 +241,12 @@ func (g *Graph) PutPagesInContext() {
 func (g *Graph) ResourceLinks() []*Link {
 	links := []*Link{}
 
-	for _, page := range g.Pages {
-		log.Debug("Checking resource links in ", page.Name)
-		links = append(links, page.ResourceLinks()...)
+	for _, link := range g.Links() {
+		if link.LinkType == LinkTypeResource {
+			links = append(links, link)
+		}
 	}
+
 	log.Debug("Resource links found: ", len(links))
 
 	return links
@@ -248,29 +263,40 @@ func (g *Graph) prepPageForSite(page *Page) {
 
 func (g *Graph) prepBlockForSite(block *Block) {
 	blockMarkdown := block.Content.Markdown
-	log.Debug("Prepping block ", block.ID, " with ", len(block.Content.PageLinks), " page links")
+	pageLinksFromBlock := []*Link{}
+
+	for _, link := range block.Content.Links {
+		if link.LinkType == LinkTypePage {
+			pageLinksFromBlock = append(pageLinksFromBlock, link)
+		}
+	}
+
+	log.Debug("Prepping block ", block.ID, " with ", len(pageLinksFromBlock), " page links")
 	log.Debug("Initial block Markdown: ", blockMarkdown)
 
-	for i := 0; i < len(block.Content.PageLinks); i++ {
-		link := block.Content.PageLinks[i]
+	for i := 0; i < len(pageLinksFromBlock); i++ {
+		link := pageLinksFromBlock[i]
 		log.Debug("Raw link: ", link.Raw)
+		if link.LinkPath == "" {
+			// Probably a bug in link-finding logic, so log the block content.
+			log.Warning("Empty link in block content: ", block.Content.Markdown)
+			continue
+		}
+
 		linkString := "*" + link.Label + "*"
-		linkTarget := link.LinksTo.(*Page)
-		permalink, err := linkTarget.InContext(*g)
+		permalink := "/" + link.LinkPath
+
+		targetPage, err := g.FindPage(link.LinkPath)
 		if err != nil {
 			if _, ok := err.(DisconnectedPageError); ok {
 				log.Warnf("Block %v placeholder link: >%v<", block.ID, link.Label)
-
-				if linkTarget.Name == "" {
-					// Probably a bug in link-finding logic, so log the block content.
-					log.Info("Block content: ", block.Content.Markdown)
-				}
 			} else {
 				log.Fatalf("Linking page: %v", err)
 			}
 		}
 
-		if permalink != "" {
+		if targetPage != nil {
+			permalink = "/" + targetPage.PathInSite
 			log.Debug("Linking ", block.ID, " to ", permalink)
 			linkString = "[" + link.Label + "](" + permalink + ")"
 		}

--- a/logseq/link.go
+++ b/logseq/link.go
@@ -1,26 +1,42 @@
 package logseq
 
-// Linkable is an interface for types that can be linked to in a Logseq graph.
-type Linkable interface {
-	// PathInContext returns the path to the linkable in the context of the given graph.
-	InContext(Graph) (string, error)
-}
+type LinkType string
 
-// ExternalResource represents a resource that is external to the Logseq graph.
-type ExternalResource struct {
-	Uri string `json:"uri"`
-}
-
-// InContext returns the URI of the external resource.
-func (r ExternalResource) InContext(g Graph) (string, error) {
-	return r.Uri, nil
-}
+const (
+	LinkTypeAsset    LinkType = "asset"
+	LinkTypePage     LinkType = "page"
+	LinkTypeResource LinkType = "resource"
+	LinkTypeBlock    LinkType = "block"
+)
 
 // A Link connects two Linkable objects.
 type Link struct {
-	Raw       string   `json:"-"`
-	LinksFrom Linkable `json:"from"`
-	LinksTo   Linkable `json:"to"`
+	Raw       string   `json:"raw"`
+	LinksFrom *Block   `json:"from"`
+	LinkPath  string   `json:"link_path"`
+	LinkType  LinkType `json:"link_type"`
 	IsEmbed   bool     `json:"is_embed"`
 	Label     string   `json:"label"`
+}
+
+// Convenience methods in case I change the implementation details.
+
+// IsAsset returns true if the link is an asset link.
+func (l *Link) IsAsset() bool {
+	return l.LinkType == LinkTypeAsset
+}
+
+// IsBlock returns true if the link is a block link.
+func (l *Link) IsBlock() bool {
+	return l.LinkType == LinkTypeBlock
+}
+
+// IsPage returns true if the link is a page link.
+func (l *Link) IsPage() bool {
+	return l.LinkType == LinkTypePage
+}
+
+// IsResource returns true if the link is a resource link.
+func (l *Link) IsResource() bool {
+	return l.LinkType == LinkTypeResource
 }

--- a/logseq/link.go
+++ b/logseq/link.go
@@ -12,7 +12,7 @@ const (
 // A Link connects two Linkable objects.
 type Link struct {
 	Raw       string   `json:"raw"`
-	LinksFrom *Block   `json:"from"`
+	LinksFrom *Block   `json:"-"`
 	LinkPath  string   `json:"link_path"`
 	LinkType  LinkType `json:"link_type"`
 	IsEmbed   bool     `json:"is_embed"`

--- a/logseq/link_test.go
+++ b/logseq/link_test.go
@@ -8,11 +8,50 @@ import (
 	"export-logseq/logseq"
 )
 
-func TestExternalResource_InContext(t *testing.T) {
-	graph := logseq.NewGraph()
-	resource := ExternalResource()
-	path, err := resource.InContext(*graph)
+func TestLink_IsBlock(t *testing.T) {
+	link := logseq.Link{
+		LinkPath: "test-block",
+		LinkType: logseq.LinkTypeBlock,
+	}
 
-	assert.NoError(t, err)
-	assert.Equal(t, resource.Uri, path)
+	assert.True(t, link.IsBlock())
+
+	link.LinkType = logseq.LinkTypePage
+	assert.False(t, link.IsBlock())
+}
+
+func TestLink_IsAsset(t *testing.T) {
+	link := logseq.Link{
+		LinkPath: "test-asset",
+		LinkType: logseq.LinkTypeAsset,
+	}
+
+	assert.True(t, link.IsAsset())
+
+	link.LinkType = logseq.LinkTypePage
+	assert.False(t, link.IsAsset())
+}
+
+func TestLink_IsPage(t *testing.T) {
+	link := logseq.Link{
+		LinkPath: "test-page",
+		LinkType: logseq.LinkTypePage,
+	}
+
+	assert.True(t, link.IsPage())
+
+	link.LinkType = logseq.LinkTypeAsset
+	assert.False(t, link.IsPage())
+}
+
+func TestLink_IsResource(t *testing.T) {
+	link := logseq.Link{
+		LinkPath: "test-resource",
+		LinkType: logseq.LinkTypeResource,
+	}
+
+	assert.True(t, link.IsResource())
+
+	link.LinkType = logseq.LinkTypeAsset
+	assert.False(t, link.IsResource())
 }

--- a/logseq/page.go
+++ b/logseq/page.go
@@ -133,12 +133,12 @@ func (p *Page) IsPublic() bool {
 	return p.Root.IsPublic()
 }
 
-// PageLinks returns all page links found in the page.
-func (p *Page) PageLinks() []*Link {
+// Links returns links collected from all blocks in the page.
+func (p *Page) Links() []*Link {
 	links := []*Link{}
 
 	for _, block := range p.AllBlocks {
-		links = append(links, block.PageLinks()...)
+		links = append(links, block.Links()...)
 	}
 
 	return links
@@ -147,17 +147,6 @@ func (p *Page) PageLinks() []*Link {
 // Properties returns the root block's properties.
 func (p *Page) Properties() *PropertyMap {
 	return p.Root.Properties
-}
-
-// ResourceLinks returns all resource links found in the page.
-func (p *Page) ResourceLinks() []*Link {
-	links := []*Link{}
-
-	for _, block := range p.AllBlocks {
-		links = append(links, block.ResourceLinks()...)
-	}
-
-	return links
 }
 
 func (p *Page) String() string {

--- a/logseq/page_test.go
+++ b/logseq/page_test.go
@@ -3,6 +3,7 @@ package logseq_test
 import (
 	"testing"
 
+	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/assert"
 
 	"export-logseq/logseq"
@@ -113,23 +114,24 @@ func TestPage_IsPublic_FromRoot(t *testing.T) {
 	assert.False(t, page.IsPublic())
 }
 
-func TestPage_PageLinks_Empty(t *testing.T) {
+func TestPage_Links_Empty(t *testing.T) {
 	page := logseq.NewEmptyPage()
-	pageLinks := page.PageLinks()
 
-	assert.NotNil(t, pageLinks)
-	assert.Empty(t, pageLinks)
+	assert.Empty(t, page.Links())
 }
 
-func TestPage_PageLinks_FromRoot(t *testing.T) {
+func TestPage_Links_FromRoot(t *testing.T) {
 	page := logseq.NewEmptyPage()
-	block := logseq.NewEmptyBlock()
-	pageName, label := PageName(), LinkLabel()
-	link, _ := block.Content.AddLinkToPage(pageName, label)
-	page.SetRoot(block)
-	links := page.PageLinks()
+	link := logseq.Link{
+		LinkPath: gofakeit.URL(),
+		Label:    gofakeit.Phrase(),
+		LinkType: logseq.LinkTypeResource,
+		IsEmbed:  false,
+	}
+	link, _ = page.Root.Content.AddLink(link)
+	links := page.Links()
 
-	assert.Contains(t, links, link)
+	assert.Contains(t, links, &link)
 }
 
 func TestPage_Properties_Empty(t *testing.T) {
@@ -150,17 +152,6 @@ func TestPage_Properties_FromRoot(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.Equal(t, "123", got.Value)
-}
-
-func TestPage_ResourceLinks(t *testing.T) {
-	page := logseq.NewEmptyPage()
-	block := logseq.NewEmptyBlock()
-	resource, label := ExternalResource(), LinkLabel()
-	link, _ := block.Content.AddLinkToResource(resource, label)
-	page.SetRoot(block)
-	links := page.ResourceLinks()
-
-	assert.Contains(t, links, link)
 }
 
 func TestPage_SetRoot(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -45,10 +45,14 @@ func main() {
 
 	enc := json.NewEncoder(exportFile)
 	enc.SetIndent("", "  ")
-	enc.Encode(graph)
+	err = enc.Encode(graph)
+	if err != nil {
+		log.Fatal("encoding graph:", err)
+	}
+
 	log.Info("All done!")
 	elapsed := time.Since(start)
 	pageCount := len(graph.Pages)
-	log.Infof("Exported %d pages", pageCount)
+	log.Infof("Exported %d pages to: %s", pageCount, exportPath)
 	log.Infof("Elapsed time: %s", elapsed)
 }


### PR DESCRIPTION
## Issue

#1 Simplify link handling

## Highlights

- `BlockContent.AddLink(link)` handles all new links
- the bubble exists, but it's tighter: `Block.Links()`, `Page.Links()`, `Graph.Links()`
- Graph handles link processing
- slightly improved error catching

## Not Implemented

Considered but pulled myself back in.

- performance optimization
- additional data in JSON to simplify my publishing workflow
